### PR TITLE
Simplify API of #perform

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ Based on the desired conversion, use one of the following classes. In both cases
 
 ```ruby
 xml = '<alice>bob</alice>'
-json = Dachsfisch::XML2JSONConverter.new(xml: xml)
+json = Dachsfisch::XML2JSONConverter.perform(xml: xml)
 ```
 
 ### JSON-to-XML
 
 ```ruby
 json = '{ "alice": { "$" : "bob" } }'
-xml = Dachsfisch::JSON2XMLConverter.new(json: json)
+xml = Dachsfisch::JSON2XMLConverter.perform(json: json)
 ```
 
 ## Development

--- a/lib/dachsfisch.rb
+++ b/lib/dachsfisch.rb
@@ -4,6 +4,7 @@ require 'nokogiri'
 require 'json'
 
 require 'dachsfisch/version'
+require 'dachsfisch/converter_base'
 require 'dachsfisch/xml2_json_converter'
 require 'dachsfisch/json2_xml_converter'
 require 'dachsfisch/errors'

--- a/lib/dachsfisch/converter_base.rb
+++ b/lib/dachsfisch/converter_base.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Dachsfisch
+  class ConverterBase
+    def self.perform(**args)
+      new(**args).execute
+    end
+  end
+end

--- a/lib/dachsfisch/json2_xml_converter.rb
+++ b/lib/dachsfisch/json2_xml_converter.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 module Dachsfisch
-  class JSON2XMLConverter
+  class JSON2XMLConverter < ConverterBase
     def initialize(json:)
+      super()
       @json_hash = JSON.parse json
       if @json_hash.length > 1
         raise InvalidJSONInputError.new('multiple root nodes are not supported')
@@ -11,7 +12,7 @@ module Dachsfisch
       raise InvalidJSONInputError.new(e.message)
     end
 
-    def perform
+    def execute
       Nokogiri::XML::Builder.new do |xml|
         add_element xml, @json_hash
       end.to_xml

--- a/lib/dachsfisch/xml2_json_converter.rb
+++ b/lib/dachsfisch/xml2_json_converter.rb
@@ -1,17 +1,20 @@
 # frozen_string_literal: true
 
 module Dachsfisch
-  class XML2JSONConverter
+  class XML2JSONConverter < ConverterBase
     def initialize(xml:)
+      super()
       @doc = Nokogiri::XML(xml)
       raise InvalidXMLInputError.new('input empty') if xml.nil? || xml.empty?
       raise InvalidXMLInputError.new(@doc.errors) if @doc.errors.length.positive?
     end
 
-    def perform
+    def execute
       root = @doc.root
       {root.name => extract_node(root)}.to_json
     end
+
+    private
 
     def extract_node(node)
       hash = {}
@@ -23,8 +26,6 @@ module Dachsfisch
       end
       hash
     end
-
-    private
 
     def handle_content(hash, child)
       case child.class.to_s # use string representation because CData inherits Text

--- a/spec/dachsfisch/json2_xml_converter_spec.rb
+++ b/spec/dachsfisch/json2_xml_converter_spec.rb
@@ -36,9 +36,7 @@ RSpec.describe Dachsfisch::JSON2XMLConverter do
   end
 
   describe '#perform' do
-    subject { converter.perform }
-
-    let(:converter) { described_class.new json: }
+    subject { described_class.perform json: }
 
     Examples.each :json2xml do |example|
       context "with #{example.name}" do

--- a/spec/dachsfisch/xml2_json_converter_spec.rb
+++ b/spec/dachsfisch/xml2_json_converter_spec.rb
@@ -36,9 +36,7 @@ RSpec.describe Dachsfisch::XML2JSONConverter do
   end
 
   describe '#perform' do
-    subject { converter.perform }
-
-    let(:converter) { described_class.new xml: }
+    subject { described_class.perform xml: }
 
     Examples.each :xml2json do |example|
       context "with #{example.name}" do


### PR DESCRIPTION
I added a `ConverterBase` class to wrap the instant perform in a central place (similar to the services in codeharbor)