### PR TITLE
Fix overwriting of attributes

### DIFF
--- a/lib/dachsfisch/xml2_json_converter.rb
+++ b/lib/dachsfisch/xml2_json_converter.rb
@@ -20,9 +20,10 @@ module Dachsfisch
       hash = {}
       active_namespaces = add_namespaces_to_active_namespaces(node)
       hash['@xmlns'] = active_namespaces unless active_namespaces.empty?
+
+      handle_attributes(hash, node)
       node.children.each do |child|
         handle_content(hash, child)
-        handle_attributes(hash, node)
       end
       hash
     end

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -274,6 +274,28 @@ module Examples
     end
   end
 
+  class CustomExampleEmptyNodeWithAttribute < ExampleBase
+    def self.json
+      <<~JSON
+        {
+          "alice": {
+            "bob": {
+              "@foo": "bar"
+            }
+          }
+        }
+      JSON
+    end
+
+    def self.xml
+      <<-XML
+        <alice>
+          <bob foo="bar"/>
+        </alice>
+      XML
+    end
+  end
+
   class CustomExampleCdata < ExampleBase
     def self.json
       <<~JSON


### PR DESCRIPTION
I encountered a bug where the attributes of a node-group were not converted to json correctly.

The handling of the attributes was in the child-loop.