### PR TITLE
fix reserved name error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dachsfisch (0.1.0)
+    dachsfisch (0.1.1)
       nokogiri (>= 1.14.1, < 2.0.0)
 
 GEM

--- a/lib/dachsfisch/json2_xml_converter.rb
+++ b/lib/dachsfisch/json2_xml_converter.rb
@@ -31,7 +31,8 @@ module Dachsfisch
     def add_node(xml, key, element)
       case element
         when Hash
-          node = xml.send(key) { add_element(xml, element) }
+          # underscore is used to disambiguate tag names from ruby methods
+          node = xml.send("#{key}_") { add_element(xml, element) }
           handle_attribute_and_namespaces(node, element)
         when Array
           element.each do |sub_element|

--- a/lib/dachsfisch/version.rb
+++ b/lib/dachsfisch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dachsfisch
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -26,6 +26,24 @@ module Examples
     end
   end
 
+  class CustomExampleWithReservedWord < ExampleBase
+    def self.json
+      <<~JSON
+        {
+          "test": {
+            "$1": "test"
+          }
+        }
+      JSON
+    end
+
+    def self.xml
+      <<-XML
+        <test>test</test>
+      XML
+    end
+  end
+
   class Example3 < ExampleBase
     def self.json
       <<~JSON


### PR DESCRIPTION
The missing underscore could call certain methods unintentionally (eg `test`)