### PR TITLE
Remove namespace redundancy when generating json

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dachsfisch (0.1.1)
+    dachsfisch (0.2.0)
       nokogiri (>= 1.14.1, < 2.0.0)
 
 GEM

--- a/lib/dachsfisch/version.rb
+++ b/lib/dachsfisch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dachsfisch
-  VERSION = '0.1.1'
+  VERSION = '0.2.0'
 end

--- a/lib/dachsfisch/xml2_json_converter.rb
+++ b/lib/dachsfisch/xml2_json_converter.rb
@@ -77,7 +77,7 @@ module Dachsfisch
     end
 
     def add_namespaces_to_active_namespaces(node)
-      node.namespaces.transform_keys {|k| convert_namespace_key(k) }
+      node.namespaces.reject {|k, v| node.parent.namespaces[k] == v }.transform_keys {|k| convert_namespace_key(k) }
     end
 
     def convert_namespace_key(key)

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -160,28 +160,20 @@ module Examples
     end
   end
 
-  class Example9 < ExampleBase
+  class Example9Modified < ExampleBase
     def self.json
       <<~JSON
         {
           "alice": {
-            "bob": {
-              "$1": "david",
-              "@xmlns": {
-                "charlie": "http://some-other-namespace",
-                "$": "http://some-namespace"
-              }
-            },
-            "charlie:edgar": {
-              "$1": "frank",
-              "@xmlns": {
-                "charlie": "http://some-other-namespace",
-                "$": "http://some-namespace"
-              }
-            },
             "@xmlns": {
               "charlie": "http://some-other-namespace",
               "$": "http://some-namespace"
+            },
+            "bob": {
+              "$1": "david"
+            },
+            "charlie:edgar": {
+              "$1": "frank"
             }
           }
         }


### PR DESCRIPTION
This change adds an additional requirement for a namespace to be added to the namespace attribute in the json format: 
- the parent node must not also have this namespace (prefix and href get both checked)