### PR TITLE
Unignore rubocop dependencies from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
     labels:
       - dependencies
       - ruby
-    ignore:
-      - dependency-name: rubocop*
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
This PR ensures Dependabot will start again to provide updates for rubocop. Previously, we disabled dependabot updates (but only temporarily). Now, it's time to enable them again.